### PR TITLE
Only admin can create categories

### DIFF
--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -1,0 +1,6 @@
+ActiveAdmin.register Category do
+
+  permit_params :name
+  filter :name
+
+end


### PR DESCRIPTION
In this branch I worked on that only _**AdminUser**_ can create categories.

![create_category](https://user-images.githubusercontent.com/43415972/51120946-31620300-17e4-11e9-9328-e6fc7b7c7818.gif)

